### PR TITLE
Updated nullable value type and enum handling

### DIFF
--- a/MapDataReader.Tests/TestActualCode.cs
+++ b/MapDataReader.Tests/TestActualCode.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+﻿using System.Data;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MapDataReader.Tests
 {
@@ -14,6 +8,20 @@ namespace MapDataReader.Tests
 		FirstDude,
 		SecondDude,
 		Third,
+	}
+	
+	public enum MyEnumByte : byte
+	{
+		FirstLady,
+		SecondLady,
+		ThirdLady
+	}
+	
+	public enum MyEnumShort : short
+	{
+		FirstChild,
+		SecondChild,
+		ThirdChild
 	}
 
 	[GenerateDataReaderMapper]
@@ -39,6 +47,13 @@ namespace MapDataReader.Tests
 
 		public MyEnum Dude { get; set; }
 		public MyEnum? NullableDude { get; set; }
+
+		public MyEnumByte Lady { get; set; }
+		public MyEnumByte? NullableLady { get; set; }
+
+		public MyEnumShort Child { get; set; }
+		public MyEnumShort? NullableChild { get; set; }
+		
 		public string Name { get; set; }
 
 		public int GetOnly { get; } = 123; //property without public setter!
@@ -137,6 +152,46 @@ namespace MapDataReader.Tests
 
 			o.SetPropertyByName("NullableDude", MyEnum.FirstDude);
 			Assert.IsTrue(o.NullableDude == MyEnum.FirstDude);
+		}
+
+		[TestMethod]
+		public void TestEnumByteAssign()
+		{
+			var o = new MyObject();
+			o.SetPropertyByName("Lady", (byte)0);
+			Assert.IsTrue(o.Lady == MyEnumByte.FirstLady);
+
+			o.SetPropertyByName("Lady", (byte)1);
+			Assert.IsTrue(o.Lady == MyEnumByte.SecondLady);
+
+			o.SetPropertyByName("Lady", 2); // Let's check with an int
+			Assert.IsTrue(o.Lady == MyEnumByte.ThirdLady);
+
+			o.SetPropertyByName("NullableLady", (byte)1);
+			Assert.IsTrue(o.NullableLady == MyEnumByte.SecondLady);
+
+			o.SetPropertyByName("NullableLady", MyEnumByte.FirstLady);
+			Assert.IsTrue(o.NullableLady == MyEnumByte.FirstLady);
+		}
+
+		[TestMethod]
+		public void TestEnumShortAssign()
+		{
+			var o = new MyObject();
+			o.SetPropertyByName("Child", (short)0);
+			Assert.IsTrue(o.Child == MyEnumShort.FirstChild);
+
+			o.SetPropertyByName("Child", (short)1);
+			Assert.IsTrue(o.Child == MyEnumShort.SecondChild);
+
+			o.SetPropertyByName("Child", 2); // Let's check with an int
+			Assert.IsTrue(o.Child == MyEnumShort.ThirdChild);
+
+			o.SetPropertyByName("NullableChild", (short)1);
+			Assert.IsTrue(o.NullableChild == MyEnumShort.SecondChild);
+
+			o.SetPropertyByName("NullableChild", MyEnumShort.FirstChild);
+			Assert.IsTrue(o.NullableChild == MyEnumShort.FirstChild);
 		}
 
 		[TestMethod]

--- a/MapDataReader.Tests/TestGenerator.cs
+++ b/MapDataReader.Tests/TestGenerator.cs
@@ -8,6 +8,12 @@ namespace MapDataReader.Tests
 	[TestClass]
 	public class TestGenerator
 	{
+		/// <summary>
+		/// Gets or sets the test context which provides
+		/// information about and functionality for the current test run.
+		/// </summary>
+		public TestContext TestContext { get; set; }
+
 		[TestMethod]
 		public void TestGeneral()
 		{
@@ -29,6 +35,8 @@ namespace MyCode
 }
 ";
 			var src = GetAndCheckOutputSource(userSource);
+			
+			TestContext.WriteLine(src);
 		}
 		
 		[TestMethod]
@@ -52,6 +60,8 @@ namespace MyCode
 }
 ";
 			var src = GetAndCheckOutputSource(userSource);
+			
+			TestContext.WriteLine(src);
 		}
 		
 		[TestMethod]
@@ -79,6 +89,8 @@ namespace MyCode
 }
 ";
 			var src = GetAndCheckOutputSource(userSource);
+			
+			TestContext.WriteLine(src);
 		}
 		
 		[TestMethod]
@@ -106,6 +118,10 @@ namespace MyCode
 }
 ";
 			var src = GetAndCheckOutputSource(userSource);
+			
+			TestContext.WriteLine("Test Passed");
+			TestContext.WriteLine("Generated Output:\n");
+			TestContext.WriteLine(src);
 		}
 
 		//gets generated source and also unit-tests for exceptions and empty diagnistics etc

--- a/MapDataReader.Tests/TestGenerator.cs
+++ b/MapDataReader.Tests/TestGenerator.cs
@@ -1,8 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using System.Collections.Immutable;
 using System.Data;
-using System.Diagnostics;
 using System.Reflection;
 
 namespace MapDataReader.Tests
@@ -50,6 +48,60 @@ namespace MyCode
 		public System.DateTime Created {get;set;}
 		public System.DateTimeOffset Offset {get;set;}
 		public decimal Price {get;set;}
+	}
+}
+";
+			var src = GetAndCheckOutputSource(userSource);
+		}
+		
+		[TestMethod]
+		public void TestEnumByte()
+		{
+			string userSource = @"
+using MapDataReader;
+
+namespace MyCode
+{
+	public enum MyEnumByte : byte
+	{
+		FirstLady,
+		SecondLady,
+		ThirdLady,
+	}
+
+	[GenerateDataReaderMapper()]
+	public class MyClass
+	{
+		public string Name {get;set;}
+		public MyEnumByte Lady {get;set;}
+		public MyEnumByte? LadyNull {get;set;}
+	}
+}
+";
+			var src = GetAndCheckOutputSource(userSource);
+		}
+		
+		[TestMethod]
+		public void TestEnumShort()
+		{
+			string userSource = @"
+using MapDataReader;
+
+namespace MyCode
+{
+	public enum MyEnumShort : short
+	{
+		FirstChild,
+		SecondChild,
+		ThirdChild,
+	}
+
+	[GenerateDataReaderMapper()]
+	public class MyClass
+	{
+		public string Name {get;set;}
+		public MyEnumShort Child {get;set;}
+		public MyEnumShort? ChildNull {get;set;}
 	}
 }
 ";

--- a/MapDataReader/MapperGenerator.cs
+++ b/MapDataReader/MapperGenerator.cs
@@ -118,7 +118,7 @@ namespace MapDataReader
 										return $"\t\tif (name == \"{p.Name.ToUpperInvariant()}\") {{ target.{p.Name} = value as {pTypeName}; return; }}";
 									}
 
-									if (pTypeName.EndsWith("?") && !p.Type.IsNullableEnum()) //nullable type (unless nullable Enum)
+									if (p.Type.TryGetNullableValueUnderlyingType(out var underlyingType) && !underlyingType.IsEnum()) //nullable type (unless nullable Enum)
 									{
 										var nonNullableTypeName = pTypeName.TrimEnd('?');
 
@@ -126,11 +126,14 @@ namespace MapDataReader
 										return $"\t\tif (name == \"{p.Name.ToUpperInvariant()}\") {{ if(value==null) target.{p.Name}=null; else if(value is {nonNullableTypeName}) target.{p.Name}=({nonNullableTypeName})value; return; }}";
 									}
 
-									if (p.Type.TypeKind == TypeKind.Enum || p.Type.IsNullableEnum())
+									if (p.Type.TryGetEnum(out var enumTypeSymbol) || underlyingType.TryGetEnum(out enumTypeSymbol))
 									{
+										var eTypeName = enumTypeSymbol.FullName(); // e.g. int, byte, short
+										
 										// enum? pre-convert to underlying type then to int, you can't cast a boxed int to enum directly.
 										// Also to support assigning "smallint" database col to int32 (for example), which does not work at first (you can't cast a boxed "byte" to "int")
-										return $"\t\tif (value != null && name == \"{p.Name.ToUpperInvariant()}\") {{ target.{p.Name} = ({pTypeName})(value.GetType() == typeof(int) ? (int)value : (int)Convert.ChangeType(value, typeof(int))); return; }}"; //pre-convert enums to int first (after unboxing, see below)
+										// pre-convert enums to eTypeName (int, byte, short) first (after unboxing, see below)
+										return $"\t\tif (value != null && name == \"{p.Name.ToUpperInvariant()}\") {{ target.{p.Name} = ({pTypeName})(value.GetType() == typeof({eTypeName}) ? ({eTypeName})value : ({eTypeName})Convert.ChangeType(value, typeof({eTypeName}))); return; }}"; 
 									}
 
 									// primitive types. use Convert.ChangeType before casting.


### PR DESCRIPTION
- This will help get the underlying value type of enums or nullable enums. This also removed dependency on checking named types as string literals by using `SpecialType.System_Nullable_T` instead. 
- Added tests for checking enums that use byte and short types.
- Also added outputting the result of the generated tests to the test results.
